### PR TITLE
fix sender for pw reset emails

### DIFF
--- a/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
@@ -170,5 +170,6 @@ ORGANISATION_BANK_CONNECTION = {"PC" : "{{cookiecutter.PC}}",
 SHARE_PRICE = "{{cookiecutter.share_price}}"
 
 INFO_EMAIL = "{{cookiecutter.info_email}}"
+DEFAULT_FROM_EMAIL = "{{cookiecutter.info_email}}"
 SERVER_URL = "{{cookiecutter.server_url}}"
 STYLES = {'static': ['/static/demo/css/customize.css']}


### PR DESCRIPTION
https://github.com/juntagrico/juntagrico/issues/418

~~In the future `DEFAULT_FROM_EMAIL` should probably replace `INFO_EMAIL`.~~

# TODO

- [ ] use the new contact setting starting from juntagrico 1.6 (https://github.com/juntagrico/juntagrico/issues/508)