### PR TITLE
apps.py

### DIFF
--- a/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/apps.py
+++ b/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+class {{cookiecutter.project_slug|capitalize}}Config(AppConfig):
+    name = '{{cookiecutter.project_slug}}'
+    verbose_name = "{{cookiecutter.organisation_name}}"
+
+    def ready(self):
+        pass


### PR DESCRIPTION
I read up a bit on Django Projects vs. Apps.

https://docs.djangoproject.com/en/4.2/ref/applications/#projects-and-applications
https://learndjango.com/tutorials/django-best-practices-projects-vs-apps

Currently, we are creating a combined Project/App for the instance with the name of the cooperative, which is probably fine and keeps things in one place.

What needs to go into an app (afaik) are static file overrides and custom additions that require views, forms, signal receivers etc. Static files are already in this template.

So now that we make our `{{project_slug}}` app, we may also create a boiler plate AppConfig. This, and specifically it's ready method can be used to customizations and would replace the `juntagricoapp.py` approach.