### PR TITLE
Templates

### DIFF
--- a/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
@@ -51,6 +51,8 @@ DATABASES = {
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'DIRS': [os.path.join(BASE_DIR, 'templates')],
         'OPTIONS': {
             'context_processors': [
                 'django.contrib.auth.context_processors.auth',
@@ -62,11 +64,7 @@ TEMPLATES = [
                 'django.template.context_processors.request',
                 'django.contrib.messages.context_processors.messages',
             ],
-            'loaders': [
-                'django.template.loaders.filesystem.Loader',
-                'django.template.loaders.app_directories.Loader'
-            ],
-            'debug' : True
+            'debug' : DEBUG,
         },
     },
 ]


### PR DESCRIPTION
put all prerequisites in place, e.g. templates settings, such that templates only need to be copied to override them.

also only debug templates in debug mode.