### PR TITLE
Show errors and warnings in log by default

### DIFF
--- a/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
@@ -217,6 +217,7 @@ ORGANISATION_BANK_CONNECTION = {"PC" : "{{cookiecutter.PC}}",
             "BIC" : "{{cookiecutter.BIC}}",
             "NAME" : "{{cookiecutter.NAME}}",
             "ESR" : "{{cookiecutter.ESR}}"}
+ENABLE_SHARES = True
 SHARE_PRICE = "{{cookiecutter.share_price}}"
 
 CONTACTS = {

--- a/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
@@ -16,14 +16,20 @@ DEBUG = os.environ.get("JUNTAGRICO_DEBUG", 'False')=='True'
 LOGGING = {
     'version': 1,
     'disable_existing_loggers': False,
+    'formatters': {
+        'simple': {'format': '[%(asctime)s] %(levelname)s %(message)s'}
+    },
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
+            'formatter': 'simple',
         },
     },
-    'root': {
-        'handlers': ['console'],
-        'level': 'WARNING',
+    'loggers': {
+        '': {
+            'handlers': ['console'],
+            'level': 'WARNING',
+        },
     },
 }
 

--- a/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.code}}/{{cookiecutter.project_slug}}/settings.py
@@ -13,6 +13,20 @@ SECRET_KEY = os.environ.get('JUNTAGRICO_SECRET_KEY')
 
 DEBUG = os.environ.get("JUNTAGRICO_DEBUG", 'False')=='True'
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'WARNING',
+    },
+}
+
 ALLOWED_HOSTS = ['{{cookiecutter.project_slug}}.juntagrico.science', 'localhost',]
 
 ADMINS = (


### PR DESCRIPTION
TODO:
- [x] Log time
- [ ] Don't send full report via email, but just use the email as a notification and refer to the logs. https://docs.djangoproject.com/en/4.2/ref/logging/#django.utils.log.AdminEmailHandler